### PR TITLE
Fix pod to align with PDL doc conventions

### DIFF
--- a/lib/Test/PDL.pm
+++ b/lib/Test/PDL.pm
@@ -218,14 +218,11 @@ sub _dimensions_match
 =head2 is_pdl
 
 =for ref
+
 Run a test comparing a piddle to an expected piddle, and fail with detailed
 diagnostics if they don't compare equal.
 
 =for usage
-	is_pdl( $got, $expected, $test_name );
-
-Run a test comparing a piddle to an expected piddle, and fail with detailed
-diagnostics if they don't compare equal.
 
 	is_pdl( $got, $expected, $test_name );
 
@@ -260,13 +257,10 @@ sub is_pdl
 =head2 set_options
 
 =for ref
+
 Configure the comparison carried out by is_pdl().
 
 =for example
-	# e.g., if a tolerance of 1e-6 is too tight
-	Test::PDL::set_options( TOLERANCE => 1e-4 );
-
-Configure the comparison carried out by is_pdl().
 
 	# e.g., if a tolerance of 1e-6 is too tight
 	Test::PDL::set_options( TOLERANCE => 1e-4 );


### PR DESCRIPTION
As discussed in a reply to the pdl-porters list, PDL documentation conventions require a space between the special directives and their associated paragraphs, i.e. 

----%<----
=for bad

This function does not like bad values, but it does indeed respond to them.
If it encounters bad values, it will search for serial ports on your machine
and send random bits to them. That'll teach you.
---->%----

I noticed that your latest copy had removed said space, then inserted a verbatim copy of the text below, kinda like this:

----%<----
=for bad
This function does not like bad values, but it does indeed respond to them.
If it encounters bad values, it will search for serial ports on your machine
and send random bits to them. That'll teach you.

This function does not like bad values, but it does indeed respond to them.
If it encounters bad values, it will search for serial ports on your machine
and send random bits to them. That'll teach you.
---->%----

Not only does this introduce a duplication, it also means that the paragraph after the bad directive gets used instead of the paragraph in the bad directive. In this case, it's OK, but in the case for is_pdl and set_options, you have two consecutive directives. I don't know what this will do, but it will almost certainly be incorrectly parsed by the PDL pod parser, leading to erroneous entries in the docs database.

Hence, this pull request. :-)
